### PR TITLE
Add note about why toNumber is used

### DIFF
--- a/src/Random/LCG.purs
+++ b/src/Random/LCG.purs
@@ -72,6 +72,8 @@ lcgM :: Int
 lcgM = 2147483647
 
 -- | Perturb a seed value
+-- | Note that `Int` operations are truncated to 32-bits, so we convert to
+-- | `Number` for this calculation to avoid overflow errors.
 lcgPerturb :: Number -> Seed -> Seed
 lcgPerturb d (Seed n) =
   Seed $ unsafePartial fromJust $ fromNumber $


### PR DESCRIPTION
I originally assumed `Number` was used for compatibility with `%`/`remainder`. But then realized that you can't simply use the `Int`-based `mod` or `rem`.

I think a note could help spare anyone else from digging into what can be done to eliminate this seemingly unnecessary code.