### PR TITLE
Keep number conversion implementation detail internal

### DIFF
--- a/src/Random/LCG.purs
+++ b/src/Random/LCG.purs
@@ -72,6 +72,8 @@ lcgM :: Int
 lcgM = 2147483647
 
 -- | Perturb a seed value
+-- | Note that `Int` operations are truncated to 32-bits, so we convert to
+-- | `Number` for this calculation to avoid overflow errors.
 lcgPerturb :: Number -> Seed -> Seed
 lcgPerturb d (Seed n) =
   Seed $ unsafePartial fromJust $ fromNumber $

--- a/src/Random/LCG.purs
+++ b/src/Random/LCG.purs
@@ -74,11 +74,11 @@ lcgM = 2147483647
 -- | Perturb a seed value
 -- | Note that `Int` operations are truncated to 32-bits, so we convert to
 -- | `Number` for this calculation to avoid overflow errors.
-lcgPerturb :: Number -> Seed -> Seed
+lcgPerturb :: Int -> Seed -> Seed
 lcgPerturb d (Seed n) =
   Seed $ unsafePartial fromJust $ fromNumber $
-    (toNumber lcgA * toNumber n + d) % toNumber lcgM
+    (toNumber lcgA * toNumber n + toNumber d) % toNumber lcgM
 
 -- | Step the linear congruential generator
 lcgNext :: Seed -> Seed
-lcgNext = lcgPerturb (toNumber lcgC)
+lcgNext = lcgPerturb lcgC

--- a/src/Random/LCG.purs
+++ b/src/Random/LCG.purs
@@ -72,8 +72,8 @@ lcgM :: Int
 lcgM = 2147483647
 
 -- | Perturb a seed value
--- | Note that `Int` operations are truncated to 32-bits, so we convert to
--- | `Number` for this calculation to avoid overflow errors.
+-- Note that `Int` operations are truncated to 32-bits, so we convert to
+-- `Number` for this calculation to avoid overflow errors.
 lcgPerturb :: Int -> Seed -> Seed
 lcgPerturb d (Seed n) =
   Seed $ unsafePartial fromJust $ fromNumber $


### PR DESCRIPTION
I think this code is more straightforward with all the `Number` conversions isolated as an implementation detail.

This is technically a version bump. Not sure if any other libraries use `lcgPerturb`.

Based on #6